### PR TITLE
feat: add graph_date and osm_date elements

### DIFF
--- a/gpx/v2/ors-gpx.xsd
+++ b/gpx/v2/ors-gpx.xsd
@@ -33,6 +33,8 @@
       <xs:element type="xs:string" name="attribution" minOccurs="0"/>
       <xs:element type="xs:string" name="engine" minOccurs="0"/>
       <xs:element type="xs:string" name="build_date" minOccurs="0"/>
+      <xs:element type="xs:string" name="graph_date" minOccurs="0"/>
+      <xs:element type="xs:string" name="osm_date" minOccurs="0"/>
       <xs:element type="xs:string" name="profile" minOccurs="0"/>
       <xs:element type="xs:string" name="preference" minOccurs="0"/>
       <xs:element type="xs:string" name="language" minOccurs="0"/>


### PR DESCRIPTION
Add `graph_date` and `osm_date` elements to support changes made in https://github.com/GIScience/openrouteservice/pull/2056
See issue https://github.com/GIScience/openrouteservice/issues/2055